### PR TITLE
Caseof function to safely unwrap maybes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,7 +42,7 @@ If the predicate returns true, apply the right function to the value.</p>
  a Just function (a function that takes an unwrapped value and returns any),
  a Nothing function (a function that takes no arguments and returns any).</p>
 <p>If Maybe is Nothing, the Nothing function is applied
-Otherwise, the Just function is applied to the value (Maybe[0])</p>
+otherwise, the Just function is applied to the value (Maybe[0])</p>
 <p>Example:</p>
 <pre><code class="language-javascript">const withDefault = defaultValue =&gt; caseof({
  Just: (value) =&gt; value,
@@ -158,7 +158,7 @@ Take an object with:
  a Nothing function (a function that takes no arguments and returns any).
 
 If Maybe is Nothing, the Nothing function is applied
-Otherwise, the Just function is applied to the value (Maybe[0])
+otherwise, the Just function is applied to the value (Maybe[0])
 
 Example:
 ```javascript
@@ -175,7 +175,7 @@ Hint: This is just a fancy way to do branching
 
 **Returns**: <code>function</code> - A function (value:Any) => Any  
 
-| Param | Type |
-| --- | --- |
-| caseofObject | <code>Object</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| caseofObject | <code>Object</code> | An Object like { Just: (Any -> Any), Nothing: Function } |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,22 @@ If the predicate returns true, apply the right function to the value.</p>
 <dt><a href="#values">values(list)</a> ⇒ <code>Array</code></dt>
 <dd><p>Take a list of maybes and return a list of Just values, excluding Nothings.</p>
 </dd>
+<dt><a href="#caseof">caseof(caseofObject)</a> ⇒ <code>function</code></dt>
+<dd><p>Take an object with:
+ a Just function (a function that takes an unwrapped value and returns any),
+ a Nothing function (a function that takes no arguments and returns any).</p>
+<p>If Maybe is Nothing, the Nothing function is applied
+Otherwise, the Just function is applied to the value (Maybe[0])</p>
+<p>Example:</p>
+<pre><code class="language-javascript">const withDefault = defaultValue =&gt; caseof({
+ Just: (value) =&gt; value,
+ Nothing: () =&gt; defaultValue
+});
+
+withDefault(&#39;&#39;)(toMaybe(null)) // &#39;&#39;
+withDefault(&#39;&#39;)(toMaybe(&#39;foo&#39;)) // foo</code></pre>
+<p>Hint: This is just a fancy way to do branching</p>
+</dd>
 </dl>
 
 <a name="isJust"></a>
@@ -133,4 +149,33 @@ Take a list of maybes and return a list of Just values, excluding Nothings.
 | Param | Type | Description |
 | --- | --- | --- |
 | list | <code>Array</code> | An array of Maybes |
+
+<a name="caseof"></a>
+
+## caseof(caseofObject) ⇒ <code>function</code>
+Take an object with:
+ a Just function (a function that takes an unwrapped value and returns any),
+ a Nothing function (a function that takes no arguments and returns any).
+
+If Maybe is Nothing, the Nothing function is applied
+Otherwise, the Just function is applied to the value (Maybe[0])
+
+Example:
+```javascript
+const withDefault = defaultValue => caseof({
+ Just: (value) => value,
+ Nothing: () => defaultValue
+});
+
+withDefault('')(toMaybe(null)) // ''
+withDefault('')(toMaybe('foo')) // foo
+```
+
+Hint: This is just a fancy way to do branching
+
+**Returns**: <code>function</code> - A function (value:Any) => Any  
+
+| Param | Type |
+| --- | --- |
+| caseofObject | <code>Object</code> | 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,8 +41,8 @@ If the predicate returns true, apply the right function to the value.</p>
 <dd><p>Take an object with:
  a Just function (a function that takes an unwrapped value and returns any),
  a Nothing function (a function that takes no arguments and returns any).</p>
-<p>If Maybe is Nothing, the Nothing function is applied
-otherwise, the Just function is applied to the value (Maybe[0])</p>
+<p>If Maybe is Nothing, the Nothing function is applied.
+Otherwise, the Just function is applied to the value (Maybe[0])</p>
 <p>Example:</p>
 <pre><code class="language-javascript">const withDefault = defaultValue =&gt; caseof({
  Just: (value) =&gt; value,
@@ -157,8 +157,8 @@ Take an object with:
  a Just function (a function that takes an unwrapped value and returns any),
  a Nothing function (a function that takes no arguments and returns any).
 
-If Maybe is Nothing, the Nothing function is applied
-otherwise, the Just function is applied to the value (Maybe[0])
+If Maybe is Nothing, the Nothing function is applied.
+Otherwise, the Just function is applied to the value (Maybe[0])
 
 Example:
 ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -80,24 +80,20 @@ const values = list => [].concat(...list.filter(isJust));
  *  a Nothing function (a function that takes no arguments and returns any).
  *
  * If Maybe is Nothing, the Nothing function is applied.
- * Otherwise, the Just function is applied to the value (Maybe[0])
- * 
+ * Otherwise, the Just function is applied to the value (Maybe[0]).
  * Example:
  * ```javascript
  * const withDefault = defaultValue => caseof({
  *  Just: (value) => value,
  *  Nothing: () => defaultValue
  * });
- * 
  * withDefault('')(toMaybe(null)) // ''
  * withDefault('')(toMaybe('foo')) // foo
  * ```
- * 
  * Hint: This is just a fancy way to do branching
  *
  * @param {Object} caseofObject An Object like { Just: (Any -> Any), Nothing: Function }
  * @return {Function} A function (value:Any) => Any
- *
  */
 const caseof = ({ Just, Nothing }) => Maybe =>
   isNothing(Maybe) ? Nothing() : Just(Maybe[0]);

--- a/src/index.js
+++ b/src/index.js
@@ -80,7 +80,7 @@ const values = list => [].concat(...list.filter(isJust));
  *  a Nothing function (a function that takes no arguments and returns any).
  *
  * If Maybe is Nothing, the Nothing function is applied
- * Otherwise, the Just function is applied to the value (Maybe[0])
+ * otherwise, the Just function is applied to the value (Maybe[0])
  * 
  * Example:
  * ```javascript
@@ -95,7 +95,7 @@ const values = list => [].concat(...list.filter(isJust));
  * 
  * Hint: This is just a fancy way to do branching
  *
- * @param {Object} caseofObject
+ * @param {Object} caseofObject An Object like { Just: (Any -> Any), Nothing: Function }
  * @return {Function} A function (value:Any) => Any
  *
  */

--- a/src/index.js
+++ b/src/index.js
@@ -76,14 +76,16 @@ const values = list => [].concat(...list.filter(isJust));
 
 /**
  * Take an object with:
- *  a Just function (a function that take an unwrapped value and return any),
- *  a Nothing function (a function that take no arguments and return any).
+ *  a Just function (a function that takes an unwrapped value and returns any),
+ *  a Nothing function (a function that takes no arguments and returns any).
  *
- * If Maybe is Nothing, apply the Just function to the value (Maybe[0])
- * Otherwise, apply the just function
+ * If Maybe is Nothing, the Nothing function is applied
+ * Otherwise, the Just function is applied to the value (Maybe[0])
+ * 
+ * Hint: This is just a fancy way to do branching
  *
- * @param {{ Just: any => any, Nothing: () => any }}
- * @return {Function} A function (Maybe) => Any
+ * @param {{ Just: any => any, Nothing: () => any }} caseofObject
+ * @return {Function} A function (value:Any) => Any
  *
  */
 const caseof = ({ Just, Nothing }) => Maybe =>

--- a/src/index.js
+++ b/src/index.js
@@ -82,9 +82,20 @@ const values = list => [].concat(...list.filter(isJust));
  * If Maybe is Nothing, the Nothing function is applied
  * Otherwise, the Just function is applied to the value (Maybe[0])
  * 
+ * Example:
+ * ```javascript
+ * const withDefault = defaultValue => caseof({
+ *  Just: (value) => value,
+ *  Nothing: () => defaultValue
+ * });
+ * 
+ * withDefault('')(toMaybe(null)) // ''
+ * withDefault('')(toMaybe('foo')) // foo
+ * ```
+ * 
  * Hint: This is just a fancy way to do branching
  *
- * @param {{ Just: any => any, Nothing: () => any }} caseofObject
+ * @param {Object} caseofObject
  * @return {Function} A function (value:Any) => Any
  *
  */

--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,8 @@ const values = list => [].concat(...list.filter(isJust));
  *  a Just function (a function that takes an unwrapped value and returns any),
  *  a Nothing function (a function that takes no arguments and returns any).
  *
- * If Maybe is Nothing, the Nothing function is applied
- * otherwise, the Just function is applied to the value (Maybe[0])
+ * If Maybe is Nothing, the Nothing function is applied.
+ * Otherwise, the Just function is applied to the value (Maybe[0])
  * 
  * Example:
  * ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -74,12 +74,28 @@ const branch = (predicate, left, right) => value =>
  */
 const values = list => [].concat(...list.filter(isJust));
 
+/**
+ * Take an object with:
+ *  a Just function (a function that take an unwrapped value and return any),
+ *  a Nothing function (a function that take no arguments and return any).
+ *
+ * If Maybe is Nothing, apply the Just function to the value (Maybe[0])
+ * Otherwise, apply the just function
+ *
+ * @param {{ Just: any => any, Nothing: () => any }}
+ * @return {Function} A function (Maybe) => Any
+ *
+ */
+const caseof = ({ Just, Nothing }) => Maybe =>
+  isNothing(Maybe) ? Nothing() : Just(Maybe[0]);
+
 module.exports = {
   toMaybe,
   maybe,
   values,
   fallback,
   branch,
+  caseof,
   isJust,
   isNothing
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,7 +7,8 @@ import {
   fallback,
   isJust,
   isNothing,
-  branch
+  branch,
+  caseof
 } from './index.js';
 
 describe('toMaybe', async assert => {
@@ -177,6 +178,38 @@ describe('isNothing', async assert => {
     should: 'return true',
     actual: isNothing(toMaybe()),
     expected: true
+  });
+});
+
+describe('caseof', async assert => {
+  assert({
+    given: 'a maybe that is Nothing',
+    should: 'apply the Nothing function',
+    actual: caseof({
+      Just: value => `Just ${value}`,
+      Nothing: () => 'Nothing'
+    })(toMaybe()),
+    expected: 'Nothing'
+  });
+
+  assert({
+    given: 'a maybe that is not Nothing',
+    should: 'apply the Just function to the value',
+    actual: caseof({
+      Just: value => `Just ${value}`,
+      Nothing: () => 'Nothing'
+    })(toMaybe([1])),
+    expected: 'Just 1'
+  });
+
+  assert({
+    given: 'a maybe that is not Nothing',
+    should: 'apply the Just function',
+    actual: caseof({
+      Just: () => `Just`,
+      Nothing: () => 'Nothing'
+    })(toMaybe([1])),
+    expected: 'Just'
   });
 });
 


### PR DESCRIPTION
Hi there!
I've been working with maybes for a while and I've found very interesting this maybe-array approach. Thus, I think is interesting to have this 'caseof' function to unwrap maybes. I have borrowed this feature from Elm lang Maybes which is an amazing language build over Javascript.

This function will allow you to unwrap the value as follows:
```
caseof({
    Just: value => value,
    Nothing: () => 'default value',
})(toMaybe([1]))
```
I like it because it's clean and it gives you a way to understand maybes as boxes, so you must decide what to do when this box is empty or not.

For instance, you could use this function to build a withDefault function easily:
```
const withDefault => defaultValue => maybe => caseof({
    Just: value => value,
    Nothing: () => defaultValue,
})(maybe);
```

Also, I have wanted to make this function curried.

By the way: I've fallen in love with your test environment! I want to throw away Jest!

What do you think?